### PR TITLE
Prepare rake task to backfill blurhash metadata

### DIFF
--- a/lib/tasks/active_storage/blurhash_tasks.rake
+++ b/lib/tasks/active_storage/blurhash_tasks.rake
@@ -1,4 +1,15 @@
-# desc "Explaining what the task does"
-# task :active_storage_blurhash do
-#   # Task goes here
-# end
+# frozen_string_literal: true
+
+namespace :active_storage_blurhash do
+  desc "Backfill blurhash metadata for existing ActiveStorage image attachments"
+  task backfill: :environment do
+    batch_size = ENV["BATCH_SIZE"]&.to_i || 1000
+
+    ActiveStorage::Attachment
+      .joins(:blob)
+      .where("content_type LIKE ?", "image/%")
+      .find_each(batch_size: batch_size) do |attachment|
+      attachment.analyze_later
+    end
+  end
+end


### PR DESCRIPTION
Luckily, ActiveStorage comes with an AnalyzeJob of its own. So all that's left to do here is let the user (optionally) specify a batch size for the backfill rake task (in order to prevent OOM errors) and call it.