### PR TITLE
Blurhash image tag helper

### DIFF
--- a/active_storage-blurhash.gemspec
+++ b/active_storage-blurhash.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rails", ">= 7.1.3.4"
   spec.add_development_dependency "mini_magick"
+  spec.add_development_dependency "nokogiri"
   spec.add_development_dependency "ruby-vips"
   spec.add_development_dependency "standard"
 end

--- a/app/helpers/blurhash_image_helper.rb
+++ b/app/helpers/blurhash_image_helper.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module BlurhashImageHelper
+  def blurhash_image_tag(source, options = {})
+    case source
+    when String
+      # if a URL is passed, we have to manually re-hydrate the blob from it
+      path_parameters = Rails.application.routes.recognize_path(source)
+      blob = ActiveStorage::Blob.find_signed!(path_parameters[:signed_blob_id] || path_parameters[:signed_id])
+    when ActiveStorage::Blob
+      blob = source
+    when ActiveStorage::Attached::One
+      blob = source.blob
+    when ActiveStorage::VariantWithRecord
+      blob = source.blob
+      size = source.variation.transformations[:resize]
+    end
+
+    blurhash = blob.metadata["blurhash"]
+    size ||= "#{blob.metadata["width"]}x#{blob.metadata["height"]}"
+
+    if !!blurhash
+      options[:loading] = "lazy"
+      options[:size] = size
+
+      wrapper_class = options.delete(:wrapper_class)
+      canvas_class = options.delete(:canvas_class)
+      tag.div class: wrapper_class, data: {blurhash: blurhash}, style: "position: relative" do
+        image_tag(source, options) + tag.canvas(style: "position: absolute; inset: 0; transition-property: opacity; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); transition-duration: 150ms;", class: canvas_class)
+      end
+    else
+      image_tag(source, options)
+    end
+  rescue ActionController::RoutingError
+    image_tag(source, options)
+  end
+end

--- a/test/dummy/app/models/post.rb
+++ b/test/dummy/app/models/post.rb
@@ -1,0 +1,3 @@
+class Post < ApplicationRecord
+  has_one_attached :feature_image
+end

--- a/test/dummy/db/migrate/20240702081824_create_posts.rb
+++ b/test/dummy/db/migrate/20240702081824_create_posts.rb
@@ -1,0 +1,8 @@
+class CreatePosts < ActiveRecord::Migration[7.1]
+  def change
+    create_table :posts do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_17_134411) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_02_081824) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -37,6 +37,11 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_17_134411) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "posts", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/test/helpers/blurhash_image_helper.rb
+++ b/test/helpers/blurhash_image_helper.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+BLOB_URL = "http://test.host/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--ac8251860f17b296fab2d818b444ca954a0fea8b/tulips.jpg".freeze
+
+class BlurhashImageHelperTest < ActionView::TestCase
+  test "falls back to a regular image_tag when passed an arbitrary asset" do
+    html = blurhash_image_tag("image.png")
+
+    assert_equal '<img src="/images/image.png" />', html
+  end
+
+  test "falls back to a regular image_tag when blurhash isn't present in the blob's metadata" do
+    blob = create_file_blob(filename: "tulips.jpg", content_type: "image/jpg")
+
+    html = blurhash_image_tag(blob)
+
+    assert_equal "<img src=\"#{BLOB_URL}\" />", html
+  end
+
+  test "resolves an analyzed blob" do
+    blob = prepare_analyzed_blob
+
+    element = Nokogiri::HTML.fragment(blurhash_image_tag(blob))
+
+    assert_output(element, blob)
+  end
+
+  test "resolves an analyzed attachment" do
+    blob = prepare_analyzed_blob
+    post = Post.create
+    post.feature_image.attach(blob)
+
+    element = Nokogiri::HTML.fragment(blurhash_image_tag(post.feature_image))
+
+    assert_output(element, blob)
+  end
+
+  test "resolves an analyzed attachment variant" do
+    blob = prepare_analyzed_blob
+    post = Post.create
+    post.feature_image.attach(blob)
+
+    element = Nokogiri::HTML.fragment(blurhash_image_tag(post.feature_image.variant(resize: "400x300")))
+
+    # we have to make sure the resized dimensions are applied
+    assert_output(element, blob, "http://test.host/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--ac8251860f17b296fab2d818b444ca954a0fea8b/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJqcGciLCJyZXNpemUiOiI0MDB4MzAwIn0sInB1ciI6InZhcmlhdGlvbiJ9fQ==--f8ff65afca51460106c567410f3a29d540c0413e/tulips.jpg", 400, 300)
+  end
+
+  test "resolves a blob from a URL" do
+    blob = prepare_analyzed_blob
+
+    element = Nokogiri::HTML.fragment(blurhash_image_tag(BLOB_URL))
+
+    assert_output(element, blob)
+  end
+
+  test "passes wrapper css classes" do
+    blob = prepare_analyzed_blob
+
+    element = Nokogiri::HTML.fragment(blurhash_image_tag(blob, wrapper_class: "thumbnail"))
+
+    wrapper = element.css("div").first
+
+    assert_equal "thumbnail", wrapper["class"]
+  end
+
+  test "passes canvas css classes" do
+    blob = prepare_analyzed_blob
+
+    element = Nokogiri::HTML.fragment(blurhash_image_tag(blob, canvas_class: "overflow-auto"))
+
+    canvas = element.css("canvas").first
+
+    assert_equal "overflow-auto", canvas["class"]
+  end
+
+  test "passes options to image_tag" do
+    blob = prepare_analyzed_blob
+
+    element = Nokogiri::HTML.fragment(blurhash_image_tag(blob, class: "object-contain", data: {controller: "hover"}, alt: "Tulips", fetchpriority: "low"))
+
+    image = element.css("img").first
+
+    assert_equal "object-contain", image["class"]
+    assert_equal "hover", image["data-controller"]
+    assert_equal "Tulips", image["alt"]
+    assert_equal "low", image["fetchpriority"]
+  end
+
+  private
+
+  def assert_output(element, blob, url = BLOB_URL, width = blob.metadata["width"], height = blob.metadata["height"])
+    wrapper = element.css("div").first
+    image = wrapper.css("img").first
+
+    assert_equal blob.metadata["blurhash"], wrapper["data-blurhash"]
+    assert_equal width, image["width"].to_i
+    assert_equal height, image["height"].to_i
+    assert_equal "lazy", image["loading"]
+    assert_equal url, image["src"]
+  end
+
+  def prepare_analyzed_blob
+    blob = create_file_blob(filename: "tulips.jpg", content_type: "image/jpg")
+    blob.analyze
+
+    blob
+  end
+end


### PR DESCRIPTION
This PR introduces `blurhash_image_tag`, which acts as a transparent proxy around `image_tag` and decorates it with a wrapper containing a `data-blurhash` attribute.

Note that we have to consider a few cases:

1. An analyzed blob is passed. This case is straightforward, we add the `data-blurhash` to the `<div>` wrapping the `<img>` and supply an empty `<canvas>`. See https://github.com/avo-hq/active_storage-blurhash/compare/blurhash-helper?expand=1#diff-de899d272753bad8b8ace23cb529928794e6cbea915f3292d9d57f7bbc19f9d8R22
2. A single attachment is passed. Then we have to fall back to its blob, see https://github.com/avo-hq/active_storage-blurhash/compare/blurhash-helper?expand=1#diff-de899d272753bad8b8ace23cb529928794e6cbea915f3292d9d57f7bbc19f9d8R30
3. A `Variant` is passed. In this case we have to make sure that we apply the correct, possibly altered, dimensions: https://github.com/avo-hq/active_storage-blurhash/compare/blurhash-helper?expand=1#diff-de899d272753bad8b8ace23cb529928794e6cbea915f3292d9d57f7bbc19f9d8R40
4. A `String` is passed. We try to resolve a blob from it, but if we can't, fall back to a regular `image_tag`: https://github.com/avo-hq/active_storage-blurhash/compare/blurhash-helper?expand=1#diff-de899d272753bad8b8ace23cb529928794e6cbea915f3292d9d57f7bbc19f9d8R51, https://github.com/avo-hq/active_storage-blurhash/compare/blurhash-helper?expand=1#diff-de899d272753bad8b8ace23cb529928794e6cbea915f3292d9d57f7bbc19f9d8R8
5. If the passed entity resolves to a blob, but has no entity stored in the metadata, fall back to a regular `image_tag` as well: https://github.com/avo-hq/active_storage-blurhash/compare/blurhash-helper?expand=1#diff-de899d272753bad8b8ace23cb529928794e6cbea915f3292d9d57f7bbc19f9d8R14

That's it for now. Probably more edge cases will occur in the future, but for the moment this seems solid 🤞 