### PR TITLE
Store canvas data in sessionStorage and restore

### DIFF
--- a/lib/generators/active_storage/blurhash/install/templates/javascript/index.js
+++ b/lib/generators/active_storage/blurhash/install/templates/javascript/index.js
@@ -48,6 +48,11 @@ window.ActiveStorageBlurhash = {
     imageData.data.set(pixels);
     ctx.putImageData(imageData, 0, 0);
 
+    sessionStorage.setItem(
+      `active-storage-blurhash-${wrapper.dataset.blurhash}`,
+      canvas.toDataURL(),
+    );
+
     const swap = () => {
       canvas.style.opacity = "0";
     };
@@ -59,6 +64,26 @@ window.ActiveStorageBlurhash = {
       // else we need to wait for it to load
       image.onload = swap;
     }
+  },
+  restoreCanvases() {
+    const inNamespace = ([key, _payload]) =>
+      key.startsWith("active-storage-blurhash-");
+    Object.entries(sessionStorage)
+      .filter(inNamespace)
+      .forEach(([key, _payload]) => {
+        const match = /^active-storage-blurhash-(.*)/.exec(key);
+        const targetElement = document.querySelector(
+          `[data-blurhash="${match[1]}"]`,
+        );
+
+        if (targetElement) {
+          const canvas = targetElement.querySelector("canvas");
+          canvas.style.opacity = "100%";
+
+          // right now we don't do anything with the payload, since setting the opacity to 100% apparently correctly prepares the elements for caching
+          sessionStorage.removeItem(key);
+        }
+      });
   },
 };
 
@@ -75,3 +100,8 @@ document.addEventListener("turbo:load", () => {
     attributeFilter: ["data-blurhash"],
   });
 });
+
+document.addEventListener(
+  "turbo:before-cache",
+  window.ActiveStorageBlurhash.restoreCanvases,
+);


### PR DESCRIPTION
To overcome flicker when performing a Turbo restoration visit, we do two things:

1. whenever a blurhash is decoded, store it as a dataUrl in `sessionStorage`. This is a wise choice because contrary to `localStorage` it will be cleared when a browser session ends (e.g. the tab is closed)
2. before Turbo caches it, we restore the canvases (`opacity: 100%`) so the page looks correct when storing the snapshot. **Apparently this is enough and we don't need the dataUrl, just the keys in `sessionStorage`. I'd keep it though, just in case we find out some browser decides to act up 😅 **