### PR TITLE
Pin the local 'blurhash/index.js' to 'active_storage_blurhash' in ord…

### DIFF
--- a/lib/generators/active_storage/blurhash/install/install_generator.rb
+++ b/lib/generators/active_storage/blurhash/install/install_generator.rb
@@ -2,7 +2,7 @@ class ActiveStorage::Blurhash::InstallGenerator < Rails::Generators::Base
   source_root File.expand_path("templates", __dir__)
 
   def install_javascript_deps
-    if File.exist? Rails.root.join("config", "importmap.rb")
+    if importmap_present?
       say "Pinning blurhash"
       run "bin/importmap pin blurhash"
     else
@@ -16,12 +16,22 @@ class ActiveStorage::Blurhash::InstallGenerator < Rails::Generators::Base
   end
 
   def pin_blurhash_javascript
-    if File.exist? Rails.root.join("config", "importmap.rb")
+    if importmap_present?
       append_to_file "config/importmap.rb", 'pin "active_storage_blurhash", to: "blurhash/index.js"' + "\n"
     end
   end
 
   def append_to_main_javascript_entrypoint
-    append_to_file "app/javascript/application.js", "import \"active_storage_blurhash\";\n"
+    if importmap_present?
+      append_to_file "app/javascript/application.js", "import \"active_storage_blurhash\";\n"
+    else
+      append_to_file "app/javascript/application.js", "import \"./blurhash\";\n"
+    end
+  end
+
+  private
+
+  def importmap_present?
+    File.exist? Rails.root.join("config", "importmap.rb")
   end
 end

--- a/lib/generators/active_storage/blurhash/install/install_generator.rb
+++ b/lib/generators/active_storage/blurhash/install/install_generator.rb
@@ -15,7 +15,13 @@ class ActiveStorage::Blurhash::InstallGenerator < Rails::Generators::Base
     directory "javascript", "app/javascript/blurhash"
   end
 
+  def pin_blurhash_javascript
+    if File.exist? Rails.root.join("config", "importmap.rb")
+      append_to_file "config/importmap.rb", 'pin "active_storage_blurhash", to: "blurhash/index.js"' + "\n"
+    end
+  end
+
   def append_to_main_javascript_entrypoint
-    append_to_file "app/javascript/application.js", "import \"./blurhash\";\n"
+    append_to_file "app/javascript/application.js", "import \"active_storage_blurhash\";\n"
   end
 end


### PR DESCRIPTION
This PR fixes #7 where, by default, the actual JS code wouldn't load because it wasn't being pinned when using import maps.

It:

- Adds an entry to `importmap.rb` to pin `active_storage_blurhash` to `blurhash/index` within `app/javascript`.
- Replaces the previous `import "./blurhash"` with `import "./active_storage_blurhash"` to avoid any potential name conflict with the blurhash library.

I tested the changes in a dummy application with an out-of-the box install of 'active_storage-blurhash' and it works:

![active_storage_blurhash_test](https://github.com/user-attachments/assets/02009462-89c4-45ac-b962-d0edba98bc9e)
