### PR TITLE
Add 'image_processing' install to the tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # ActiveStorage::Blurhash
 
-A [blurhash](https://blurha.sh/) integration for images stored in ActiveStorage. 
+A [blurhash](https://blurha.sh/) integration for images stored in ActiveStorage.
 
 ## Motivation
+
 Elimination of layout shift and speeding up First/Largest Contentful Paint are among the primary goals for improving Core Web Vitals. For both scenarios, lazy loading images while displaying a temporary Blurhash before swapping it out for the actual image is a great way to enhance the loading experience and perceived performance.
 
 ## Usage
@@ -25,25 +26,34 @@ This will create a wrapper `<div>` containing a `<canvas>` that is going to be p
 
 Make sure to run the install generator and backfill any existing attachments (see below). New attachments should be automatically analyzed to include the blurhash metadata.
 
-
 ## Installation
-Add this line to your application's Gemfile:
+
+Add the library to your application's Gemfile:
 
 ```ruby
 gem "active_storage-blurhash"
 ```
 
+You will also need to add the "image_processing" gem to your Gemfile:
+
+```ruby
+gem "image_processing"
+```
+
 And then execute:
+
 ```bash
 $ bundle
 ```
-
 
 Install the JavaScript packages and blurhash snippet:
 
 ```bash
 $ bin/rails g active_storage:blurhash:install
 ```
+
+> [!IMPORTANT]  
+> Consider that, to make everything work, you need [libvips](https://github.com/janko/image_processing/blob/master/doc/vips.md) or [MiniMagick](https://github.com/janko/image_processing/blob/master/doc/minimagick.md) installed on your system.
 
 ## Backfilling
 
@@ -62,14 +72,15 @@ $ BATCH_SIZE=50 bin/rails active_storage_blurhash:backfill
 Note that for each blob an `AnalyzeJob` will be appended to your job processor queue.
 
 ## License
+
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
 
 ## Other gems & packages
 
- - [`avo`](https://github.com/avo-hq/avo) - Build Content management systems with Ruby on Rails
- - [`class_variants`](https://github.com/avo-hq/class_variants) - Easily configure styles and apply them as classes. Very useful when you're implementing Tailwind CSS components and call them with different states.
- - [`prop_initializer`](https://github.com/avo-hq/prop_initializer) - A flexible tool for defining properties on Ruby classes.
- - [`stimulus-confetti`](https://github.com/avo-hq/stimulus-confetti) - The easiest way to add confetti to your StimulusJS app
+- [`avo`](https://github.com/avo-hq/avo) - Build Content management systems with Ruby on Rails
+- [`class_variants`](https://github.com/avo-hq/class_variants) - Easily configure styles and apply them as classes. Very useful when you're implementing Tailwind CSS components and call them with different states.
+- [`prop_initializer`](https://github.com/avo-hq/prop_initializer) - A flexible tool for defining properties on Ruby classes.
+- [`stimulus-confetti`](https://github.com/avo-hq/stimulus-confetti) - The easiest way to add confetti to your StimulusJS app
 
 ## Try Avo ⭐️
 


### PR DESCRIPTION
This PR is a simple addition to the README: an installation step to tell users to add `gem 'image_processing'` to make everything work, and a callout at the end of the installation process to clarify that third-party dependencies like **libvips** or **Image Magick** are required.