### PR TITLE
Handle animated gif input for thumbnail

### DIFF
--- a/lib/active_storage/blurhash/thumbnail/image_magick.rb
+++ b/lib/active_storage/blurhash/thumbnail/image_magick.rb
@@ -6,7 +6,7 @@ module ActiveStorage
 
         def initialize(image)
           @thumbnail = MiniMagick::Image.open(
-            ::ImageProcessing::MiniMagick.source(image.path).resize_to_limit(200, 200).call.path
+            ::ImageProcessing::MiniMagick.source(image.path).resize_to_limit(200, 200).loader(page: 0).call.path
           )
         end
 


### PR DESCRIPTION
When using the minimagick to convert to thumbnail, only use the first frame so the result image would be static, and won't fail the number of pixel checks later in the pipeline.