### PR TITLE
Update blurhash_image_tag to accept additional styles

### DIFF
--- a/app/helpers/blurhash_image_helper.rb
+++ b/app/helpers/blurhash_image_helper.rb
@@ -27,7 +27,8 @@ module BlurhashImageHelper
 
       wrapper_class = options.delete(:wrapper_class)
       canvas_class = options.delete(:canvas_class)
-      tag.div class: wrapper_class, data: {blurhash: blurhash}, style: "position: relative" do
+      wrapper_style = options.delete(:wrapper_style)
+      tag.div class: wrapper_class, data: {blurhash: blurhash}, style: "position: relative;#{wrapper_style}" do
         image_tag(source, options) + tag.canvas(style: "position: absolute; inset: 0; transition-property: opacity; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); transition-duration: 150ms;", class: canvas_class)
       end
     else


### PR DESCRIPTION
When we use blurhashing for an image that's an child of flex box, than we lose the ability to center since the wrapping div won't have the right dimensions as the image. If we allow extra styles, we can fix small things like that on case by case basis.