### PR TITLE
docs: add note about using canvas_class for pointer-events-none

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A [blurhash](https://blurha.sh/) integration for images stored in ActiveStorage.
 
+![](./logo.png)
+
 ## Motivation
 
 Elimination of layout shift and speeding up First/Largest Contentful Paint are among the primary goals for improving Core Web Vitals. For both scenarios, lazy loading images while displaying a temporary Blurhash before swapping it out for the actual image is a great way to enhance the loading experience and perceived performance.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 A [blurhash](https://blurha.sh/) integration for images stored in ActiveStorage.
 
-![](./logo.png)
-
 ## Motivation
 
 Elimination of layout shift and speeding up First/Largest Contentful Paint are among the primary goals for improving Core Web Vitals. For both scenarios, lazy loading images while displaying a temporary Blurhash before swapping it out for the actual image is a great way to enhance the loading experience and perceived performance.
@@ -27,6 +25,25 @@ Simply swap out `image_tag` for `blurhash_image_tag` when displaying it:
 This will create a wrapper `<div>` containing a `<canvas>` that is going to be painted with the respective blurhash.
 
 Make sure to run the install generator and backfill any existing attachments (see below). New attachments should be automatically analyzed to include the blurhash metadata.
+
+## Styling Options
+
+The `blurhash_image_tag` helper accepts additional options for styling:
+
+- `wrapper_class`: CSS classes applied to the wrapper `<div>` element
+- `canvas_class`: CSS classes applied to the `<canvas>` element
+
+### Preventing Canvas from Blocking Pointer Events
+
+If you have interactive elements (links, buttons, etc.) positioned over or near blurhash images, the canvas element may block pointer events even when hidden. To fix this, add `pointer-events-none` to the `canvas_class` option:
+
+```erb
+<%= blurhash_image_tag person.avatar, 
+    class: "rounded-full", 
+    canvas_class: "pointer-events-none" %>
+```
+
+This ensures clicks pass through to underlying interactive elements. If you're using Tailwind CSS, the `pointer-events-none` utility class works perfectly for this use case.
 
 ## Installation
 


### PR DESCRIPTION
## Problem

When using `blurhash_image_tag` with interactive elements (links, buttons, etc.) positioned over or near the image, the canvas element can block pointer events even when hidden, preventing clicks from reaching underlying elements.

## Solution

This PR adds documentation about using the `canvas_class` option with `pointer-events-none` to prevent the canvas from blocking clicks. This is especially useful when using Tailwind CSS, which provides the `pointer-events-none` utility class.

## Changes

- Added a new "Styling Options" section to the README
- Documented the `wrapper_class` and `canvas_class` options
- Added a specific subsection about preventing canvas from blocking pointer events with example code

## Example

```erb
<%= blurhash_image_tag person.avatar, 
    class: "rounded-full", 
    canvas_class: "pointer-events-none" %>
```

This ensures clicks pass through to underlying interactive elements.